### PR TITLE
Fix Swift 6.2 runtime crash

### DIFF
--- a/SwiftUsdTests.xcodeproj/project.pbxproj
+++ b/SwiftUsdTests.xcodeproj/project.pbxproj
@@ -1094,6 +1094,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				OTHER_SWIFT_FLAGS = "-emit-sil";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1113,6 +1114,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				OTHER_SWIFT_FLAGS = "-emit-sil";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1133,6 +1135,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pwf.UnitTests;
@@ -1143,6 +1146,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -1154,6 +1158,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pwf.UnitTests;
@@ -1164,6 +1169,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
@@ -1190,10 +1196,10 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pwf.TestSuiteHostApplication;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1203,7 +1209,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 2.4;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -1230,10 +1236,10 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 15.4;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pwf.TestSuiteHostApplication;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1243,7 +1249,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 2.4;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};

--- a/UnitTests/Protocol conformances/CustomStringConvertibleTests.swift
+++ b/UnitTests/Protocol conformances/CustomStringConvertibleTests.swift
@@ -23,7 +23,29 @@ import OpenUSD
 
 final class CustomStringConvertibleTests: TemporaryDirectoryHelper {
     func assertConforms<T>(_ t: T.Type) {
-        XCTAssertTrue(T.self is any CustomStringConvertible.Type)
+        // rdar://165150073 (Runtime crash during `T.self is any Protocol.Type` with C++ type (Regression))
+        //
+        // When using Swift 6.2, cross-compiling, targeting an *OS 26.x platform, in Debug, `T` is a `VtArray<U>` specialization
+        // and `Protocol` is a standard library protocol (not all standard library protocols cause this issue),
+        // then `T.self is any Protocol.Type` crashes at runtime.
+        // So, avoid the `is` check in that case.
+
+        var shouldDoIsCheck = true
+        #if compiler(>=6.2) && compiler(<6.3)
+        #if !os(macOS)
+        if #available(iOS 26, visionOS 26, *) {
+            #if DEBUG
+            if T.self is any __Overlay.VtArray_WithoutCodableProtocol.Type {
+                shouldDoIsCheck = false
+            }
+            #endif // #if DEBUG
+        }
+        #endif // #if !os(macOS)
+        #endif // #if compiler(>=6.2) && compiler(<6.3)
+
+        if shouldDoIsCheck {
+            XCTAssertTrue(T.self is any CustomStringConvertible.Type)
+        }
     }
     
     func test_GfHalf() {

--- a/UnitTests/Protocol conformances/EquatableTests.swift
+++ b/UnitTests/Protocol conformances/EquatableTests.swift
@@ -25,7 +25,29 @@ import OpenUSD
 final class EquatableTests: TemporaryDirectoryHelper {
     
     func assertConforms<T>(_ t: T.Type) {
-        XCTAssertTrue(T.self is any Equatable.Type)
+        // rdar://165150073 (Runtime crash during `T.self is any Protocol.Type` with C++ type (Regression))
+        //
+        // When using Swift 6.2, cross-compiling, targeting an *OS 26.x platform, in Debug, `T` is a `VtArray<U>` specialization
+        // and `Protocol` is a standard library protocol (not all standard library protocols cause this issue),
+        // then `T.self is any Protocol.Type` crashes at runtime.
+        // So, avoid the `is` check in that case.
+
+        var shouldDoIsCheck = true
+        #if compiler(>=6.2) && compiler(<6.3)
+        #if !os(macOS)
+        if #available(iOS 26, visionOS 26, *) {
+            #if DEBUG
+            if T.self is any __Overlay.VtArray_WithoutCodableProtocol.Type {
+                shouldDoIsCheck = false
+            }
+            #endif // #if DEBUG
+        }
+        #endif // #if !os(macOS)
+        #endif // #if compiler(>=6.2) && compiler(<6.3)
+
+        if shouldDoIsCheck {
+            XCTAssertTrue(T.self is any Equatable.Type)
+        }
     }
 
     func test_GfHalf() {

--- a/UnitTests/Protocol conformances/ExpressibleByArrayLiteralTests.swift
+++ b/UnitTests/Protocol conformances/ExpressibleByArrayLiteralTests.swift
@@ -24,7 +24,29 @@ import OpenUSD
 final class ExpressibleByArrayLiteralTests: TemporaryDirectoryHelper {
     
     func assertConforms<T>(_ t: T.Type) {
-        XCTAssertTrue(T.self is any ExpressibleByArrayLiteral.Type)
+        // rdar://165150073 (Runtime crash during `T.self is any Protocol.Type` with C++ type (Regression))
+        //
+        // When using Swift 6.2, cross-compiling, targeting an *OS 26.x platform, in Debug, `T` is a `VtArray<U>` specialization
+        // and `Protocol` is a standard library protocol (not all standard library protocols cause this issue),
+        // then `T.self is any Protocol.Type` crashes at runtime.
+        // So, avoid the `is` check in that case.
+
+        var shouldDoIsCheck = true
+        #if compiler(>=6.2) && compiler(<6.3)
+        #if !os(macOS)
+        if #available(iOS 26, visionOS 26, *) {
+            #if DEBUG
+            if T.self is any __Overlay.VtArray_WithoutCodableProtocol.Type {
+                shouldDoIsCheck = false
+            }
+            #endif // #if DEBUG
+        }
+        #endif // #if !os(macOS)
+        #endif // #if compiler(>=6.2) && compiler(<6.3)
+
+        if shouldDoIsCheck {
+            XCTAssertTrue(T.self is any ExpressibleByArrayLiteral.Type)
+        }
     }
     
     func test_VtArray_Bool() {

--- a/UnitTests/Protocol conformances/SequenceTests.swift
+++ b/UnitTests/Protocol conformances/SequenceTests.swift
@@ -25,7 +25,29 @@ import Synchronization
 final class SequenceTests: TemporaryDirectoryHelper {
     
     func assertConforms<T>(_ t: T.Type) {
-        XCTAssertTrue(T.self is any Sequence.Type)
+        // rdar://165150073 (Runtime crash during `T.self is any Protocol.Type` with C++ type (Regression))
+        //
+        // When using Swift 6.2, cross-compiling, targeting an *OS 26.x platform, in Debug, `T` is a `VtArray<U>` specialization
+        // and `Protocol` is a standard library protocol (not all standard library protocols cause this issue),
+        // then `T.self is any Protocol.Type` crashes at runtime.
+        // So, avoid the `is` check in that case.
+
+        var shouldDoIsCheck = true
+        #if compiler(>=6.2) && compiler(<6.3)
+        #if !os(macOS)
+        if #available(iOS 26, visionOS 26, *) {
+            #if DEBUG
+            if T.self is any __Overlay.VtArray_WithoutCodableProtocol.Type {
+                shouldDoIsCheck = false
+            }
+            #endif // #if DEBUG
+        }
+        #endif // #if !os(macOS)
+        #endif // #if compiler(>=6.2) && compiler(<6.3)
+
+        if shouldDoIsCheck {
+            XCTAssertTrue(T.self is any Sequence.Type)
+        }
     }
     
     private func _descriptionForPrim(_ p: pxr.UsdPrim) -> String {


### PR DESCRIPTION
Add workaround for rdar://165150073 (Runtime crash during `T.self is any Protocol.Type` with C++ type (Regression))

Make deployment versions consistent for targets