### PR TITLE
SwiftUsd-Tests 6.1.0

### DIFF
--- a/ReconfigurePbxprojPackageDependency/Sources/ReconfigurePbxprojPackageDependency.swift
+++ b/ReconfigurePbxprojPackageDependency/Sources/ReconfigurePbxprojPackageDependency.swift
@@ -140,6 +140,8 @@ struct ReconfigurePbxprojPackageDependency: ParsableCommand {
             transform: URL.init(fileURLWithPath:)) var backup: URL?
     
     mutating func run() throws {
+        try findPbxprojFile()
+
         let tokenizer = try Tokenizer(fileURL: pbxprojFile)
         let tokens = try tokenizer.tokenize()
         let combined = TrivaCombiner().combine(tokens: tokens)
@@ -159,5 +161,32 @@ struct ReconfigurePbxprojPackageDependency: ParsableCommand {
         }
         
         try model.export(to: pbxprojFile)
+    }
+
+    // If the user didn't input a project.pbxproj file, try to find
+    // what they might have meant. 
+    mutating func findPbxprojFile() throws {
+        if pbxprojFile.lastPathComponent == "project.pbxproj" { return }
+        
+        if pbxprojFile.pathExtension == "xcodeproj" {
+            let newFile = pbxprojFile.appending(path: "project.pbxproj")
+            guard FileManager.default.fileExists(atPath: newFile.path(percentEncoded: false)) else {
+                throw ValidationError("Could not find project.pbxproj file under \(pbxprojFile)")
+            }
+            pbxprojFile = newFile
+            return
+        }
+        
+        if let contents = try? FileManager.default.contentsOfDirectory(at: pbxprojFile, includingPropertiesForKeys: nil) {
+            let xcodeprojs = contents.filter { $0.pathExtension == "xcodeproj" }
+            if xcodeprojs.count == 0 {
+                throw ValidationError("Could not find Xcode project under \(pbxprojFile)")
+            }
+            if xcodeprojs.count > 1 {
+                throw ValidationError("Found multiple Xcode projects under \(pbxprojFile): \(xcodeprojs.map(\.lastPathComponent))")
+            }
+            pbxprojFile = xcodeprojs.first!
+            try findPbxprojFile()
+        }
     }
 }

--- a/ReconfigurePbxprojPackageDependency/Sources/Tokenizer.swift
+++ b/ReconfigurePbxprojPackageDependency/Sources/Tokenizer.swift
@@ -138,6 +138,13 @@ struct Tokenizer {
                 var foundTerminator = false
                 while indexIsValid() {
                     quotedString.append(currentCharacter()); advance()
+                    if quotedString.last == "\\" {
+                        if indexIsValid() {
+                            quotedString.append(currentCharacter()); advance()
+                            continue
+                        }
+                    }
+
                     if quotedString.count > 1 && quotedString.last == "\"" {
                         result.append(.init(kind: .quotedString(quotedString), startIndex: startIndex, endIndex: index))
                         foundTerminator = true

--- a/SwiftUsdTests.xcodeproj/project.pbxproj
+++ b/SwiftUsdTests.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		8E45849A2B30E6930048D0C8 /* TemporaryImplementations_Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4584992B30E6930048D0C8 /* TemporaryImplementations_Swift.swift */; };
 		8E45849C2B30F48C0048D0C8 /* HelloSwiftUsdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E45849B2B30F48C0048D0C8 /* HelloSwiftUsdTests.swift */; };
 		8E45849E2B30F9D80048D0C8 /* RenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E45849D2B30F9D80048D0C8 /* RenderingTests.swift */; };
+		8E515A792F63667C0046F54C /* UsdValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E515A782F63667C0046F54C /* UsdValidationTests.swift */; };
 		8E590A902B76F00E009DE358 /* ExpressibleByFloatLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E590A8F2B76F00E009DE358 /* ExpressibleByFloatLiteralTests.swift */; };
 		8E590A922B76F321009DE358 /* ExpressibleByIntegerLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E590A912B76F321009DE358 /* ExpressibleByIntegerLiteralTests.swift */; };
 		8E5D70F52E74B2DD00C9FF66 /* OpenUSD in Frameworks */ = {isa = PBXBuildFile; productRef = 8E5D70F42E74B2DD00C9FF66 /* OpenUSD */; };
@@ -245,6 +246,7 @@
 		8E4584992B30E6930048D0C8 /* TemporaryImplementations_Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryImplementations_Swift.swift; sourceTree = "<group>"; };
 		8E45849B2B30F48C0048D0C8 /* HelloSwiftUsdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelloSwiftUsdTests.swift; sourceTree = "<group>"; };
 		8E45849D2B30F9D80048D0C8 /* RenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingTests.swift; sourceTree = "<group>"; };
+		8E515A782F63667C0046F54C /* UsdValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsdValidationTests.swift; sourceTree = "<group>"; };
 		8E590A8F2B76F00E009DE358 /* ExpressibleByFloatLiteralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressibleByFloatLiteralTests.swift; sourceTree = "<group>"; };
 		8E590A912B76F321009DE358 /* ExpressibleByIntegerLiteralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressibleByIntegerLiteralTests.swift; sourceTree = "<group>"; };
 		8E5D70A22E720F0100C9FF66 /* TestSuiteHostApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestSuiteHostApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -534,6 +536,7 @@
 		8E33E8642B2CFED900630CB4 /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				8E515A782F63667C0046F54C /* UsdValidationTests.swift */,
 				8E45849B2B30F48C0048D0C8 /* HelloSwiftUsdTests.swift */,
 				8EF209AA2F3E61CF0087B979 /* VtValueRefTests.swift */,
 				8E33E8672B2CFFBF00630CB4 /* TypeConversionTests.swift */,
@@ -914,6 +917,7 @@
 				8E33E7222B214A2700630CB4 /* PrimRangeTests.swift in Sources */,
 				8E6D42842B50967600509859 /* Observation_MutateUsdPrim_ReadUsdObject.swift in Sources */,
 				8E33E78B2B2A6C9A00630CB4 /* WrappedTypeTests.swift in Sources */,
+				8E515A792F63667C0046F54C /* UsdValidationTests.swift in Sources */,
 				8E6D42862B50973000509859 /* Observation_MutateUsdPrim_ReadUsdProperty.swift in Sources */,
 				8EA833B42D2F4AD0003BF6AD /* TfNoticeTests.mm in Sources */,
 				8E33E71E2B21482100630CB4 /* TutorialsHelper.swift in Sources */,
@@ -1315,7 +1319,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 		8E1CC7822E4A55AB00586320 /* XCRemoteSwiftPackageReference "SwiftUsd" */ = {
@@ -1323,7 +1327,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 		8E22958F2E42A7C900725E59 /* XCRemoteSwiftPackageReference "SwiftUsd" */ = {
@@ -1331,7 +1335,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 		8E811C892D8B804700F1A741 /* XCRemoteSwiftPackageReference "SwiftUsd" */ = {
@@ -1339,7 +1343,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 		8EE5A6C02EB2CC1C00C84A93 /* XCRemoteSwiftPackageReference "SwiftUsd" */ = {
@@ -1347,7 +1351,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 		8EE5A9B12ECCFFB200C84A93 /* XCRemoteSwiftPackageReference "SwiftUsd" */ = {
@@ -1355,7 +1359,7 @@
 			repositoryURL = "https://github.com/apple/SwiftUsd";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 6.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/UnitTests/ImageDiff/TestHelpers.swift
+++ b/UnitTests/ImageDiff/TestHelpers.swift
@@ -85,10 +85,10 @@ extension ImageDiffTestHelpers {
         
     func warn(_ message: String, file: StaticString = #file, line: UInt = #line) {
         let context = XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: file.description, lineNumber: Int(line)))
-        var issue = XCTIssue(type: .assertionFailure, compactDescription: message, sourceCodeContext: context)
-        #if compiler(>=6.2)
-        issue.severity = .warning
-        #endif
+        let issue = XCTIssue(type: .assertionFailure, compactDescription: message, sourceCodeContext: context)
+        // Would be nice to `issue.severity = .warning`, but there doesn't
+        // seem to be a way to do that that doesn't break compilation when
+        // a 6.3 snapshot compiles when Xcode 16.3 is the active Xcode
         record(issue)
     }
 }

--- a/UnitTests/Misc/DeprecatedTests.swift
+++ b/UnitTests/Misc/DeprecatedTests.swift
@@ -21,6 +21,7 @@
 import XCTest
 import OpenUSD
 
+#if compiler(<6.3)
 @available(*, deprecated)
 final class DeprecatedTests_Deprecated_Swift_6_1: TemporaryDirectoryHelper {
     func test_SdfLayer_IsMuted() {
@@ -107,3 +108,4 @@ final class DeprecatedTests_Deprecated_Swift_6_1: TemporaryDirectoryHelper {
         XCTAssertEqual(a, c)
     }
 }
+#endif // #if compiler(<6.3)

--- a/UnitTests/Misc/UsdValidationTests.swift
+++ b/UnitTests/Misc/UsdValidationTests.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// This source file is part of github.com/apple/SwiftUsd-Tests
+//
+// Copyright © 2025 Apple Inc. and the SwiftUsd-Tests project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import OpenUSD
+
+final class UsdValidationTests: TemporaryDirectoryHelper {
+
+    // This test is a translation of `TestCoreUsdStageMetadata` from
+    // https://github.com/PixarAnimationStudios/OpenUSD/blob/v26.03/pxr/usdValidation/usdValidation/testenv/testUsdCoreValidators.cpp
+    // into Swift.
+    func test_TestCoreUsdStageMetadata() {
+        // stageMetadataChecker
+        let registry = pxr.UsdValidationRegistry.GetInstance()
+        let validator = registry.__GetOrLoadValidatorByNameUnsafe(.UsdValidatorNameTokens.stageMetadataChecker)
+        XCTAssertNotNil(validator)
+
+        let rootLayer = Overlay.Dereference(pxr.SdfLayer.CreateAnonymous("", .init()))
+        let usdStage = Overlay.Dereference(pxr.UsdStage.Open(Overlay.TfWeakPtr(rootLayer)))
+        let prim = usdStage.DefinePrim("/test", "Xform")
+
+        var errors = validator!.pointee.Validate(Overlay.TfWeakPtr(usdStage), pxr.UsdValidationTimeRange.init())
+        XCTAssertEqual(errors.size(), 1)
+        let expectedErrorIdentifier = pxr.TfToken("\(pxr.TfToken.UsdValidatorNameTokens.stageMetadataChecker).\(pxr.TfToken.UsdValidationErrorNameTokens.missingDefaultPrim)")
+        withExtendedLifetime(errors[0]) { err in
+            XCTAssertEqual(err.__GetValidatorUnsafe(), validator)
+            XCTAssertEqual(err.GetIdentifier(), expectedErrorIdentifier)
+            XCTAssertEqual(err.GetType(), .Error)
+            XCTAssertEqual(err.__GetSitesUnsafe().pointee.size(), 1)
+            XCTAssertTrue(err.__GetSitesUnsafe().pointee[0].IsValid())
+            let expectedErrorMsg = std.string("Stage with root layer <\(rootLayer.GetIdentifier())> has an invalid or missing defaultPrim.")
+            XCTAssertEqual(err.__GetMessageUnsafe().pointee, expectedErrorMsg)
+        }
+
+        usdStage.SetDefaultPrim(prim)
+
+        errors = validator!.pointee.Validate(Overlay.TfWeakPtr(usdStage), pxr.UsdValidationTimeRange.init())
+
+        XCTAssertTrue(errors.empty())
+    }
+}

--- a/UnitTests/Protocol conformances/SequenceTests.swift
+++ b/UnitTests/Protocol conformances/SequenceTests.swift
@@ -55,7 +55,7 @@ final class SequenceTests: TemporaryDirectoryHelper {
         let rootLayerIdentifier = Overlay.Dereference(stage.GetRootLayer()).GetIdentifier()
         let sessionLayerIdentifier = Overlay.Dereference(stage.GetSessionLayer()).GetIdentifier()
         let typeName = p.GetTypeName()
-        let interpolatedTypeName = typeName == "" ? " " : "'\(typeName)' "
+        let interpolatedTypeName = typeName.IsEmpty() ? " " : "'\(typeName)' "
         let path = p.GetPath()
         return "\(interpolatedTypeName)prim <\(path)> on stage with rootLayer @\(rootLayerIdentifier)@, sessionLayer @\(sessionLayerIdentifier)@"
     }

--- a/UnitTests/Tutorials/TraversingAStage.swift
+++ b/UnitTests/Tutorials/TraversingAStage.swift
@@ -35,7 +35,7 @@ final class TraversingAStage: TutorialsHelper {
         let sessionLayerIdentifier = Overlay.Dereference(stage.GetSessionLayer()).GetIdentifier()
         let typeName = p.GetTypeName()
         let inactiveString = p.IsActive() ? "" : "inactive "
-        let interpolatedTypeName = typeName == "" ? "" : "'\(typeName)' "
+        let interpolatedTypeName = typeName.IsEmpty() ? "" : "'\(typeName)' "
         let path = p.GetPath()
         return "\(inactiveString)\(interpolatedTypeName)prim <\(path)> on stage with rootLayer @\(rootLayerIdentifier)@, sessionLayer @\(sessionLayerIdentifier)@"
     }

--- a/UnitTests/Wrapping/WrappedTypeTests.swift
+++ b/UnitTests/Wrapping/WrappedTypeTests.swift
@@ -773,7 +773,9 @@ final class WrappedTypeTests: HydraHelper {
         XCTAssertEqual(fileNames, ["src/a.txt", "src/b.png"])
         
         for file in zipFile {
-            if file.pointee == "src/b.png" { continue }
+            // rdar://158439395 (error: ambiguous use of operator '=='), 6.3 regression
+            // Workaround by using type coercion to eliminate the ambiguity
+            if file.pointee == ("src/b.png" as std.string) { continue }
             
             XCTAssertTrue(file == zipFile.Find("src/a.txt"))
             XCTAssertTrue(file != zipFile.Find("src/b.png"))

--- a/make-spm-tests.py
+++ b/make-spm-tests.py
@@ -23,7 +23,7 @@ import argparse
 import shutil
 import os
 
-DEFAULT_SWIFTUSD_VERSION = "6.0.0"
+DEFAULT_SWIFTUSD_VERSION = "6.1.0"
 
 def package_manifest_contents(args):
     version_dependency_line = f"        .package(url: \"https://github.com/apple/SwiftUsd\", from: \"{args.version}\"),\n"


### PR DESCRIPTION
Add UsdValidationTests.swift
Update SwiftUsd-Tests for Swift 6.3

ReconfigurePbxprojPackageDependency:
Try to find project.pbxproj files and Xcode projects if you use a path to an Xcode project or directory containing an Xcode proj Parse backslashes in quoted strings properly