### PR TITLE
[Hgi] Add test_HgiGLWrapper to validate binding

### DIFF
--- a/UnitTests/Wrapping/WrappedTypeTests.swift
+++ b/UnitTests/Wrapping/WrappedTypeTests.swift
@@ -86,7 +86,14 @@ final class WrappedTypeTests: HydraHelper {
         withExtendedLifetime(t) {}
     }
     #endif // #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
-    
+
+    #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
+    func test_HgiGLWrapper() {
+        let t: Overlay.HgiGLWrapper.Type = Overlay.HgiGLWrapper.self
+        withExtendedLifetime(t) {}
+    }
+    #endif // #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT)
+
     #if canImport(SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT) && canImport(Metal)
     func test_HgiMetalWrapper() {
         let t: Overlay.HgiMetalWrapper.Type = Overlay.HgiMetalWrapper.self


### PR DESCRIPTION
* Implement the `test_HgiGLWrapper` function inside `WrappedTypeTests.swift`.
* The test asserts the availability of the `Overlay.HgiGLWrapper` type under conditional `SwiftUsd_PXR_ENABLE_IMAGING_SUPPORT` compilation.

Related to apple/SwiftUsd#28