### PR TITLE
Add tests for ArAssetWrapper, ArWritableAssetWrapper

### DIFF
--- a/UnitTests/Misc/LibWorkTests.swift
+++ b/UnitTests/Misc/LibWorkTests.swift
@@ -43,7 +43,7 @@ fileprivate func assertLessThanSuppressable<T>(
         print("(SWIFTUSD_TESTS_SUPPRESS_PERFORMANCE_FAILURES): XCTAssertLessThan failed: \(l), \(r)). \(file):\(line)")
     }
     #else
-    XCTAssertLessThan(l, r, message, file: file, line: line)
+    XCTAssertLessThan(l, r, message(), file: file, line: line)
     #endif
 }
 

--- a/UnitTests/Misc/TypeConversionTests.swift
+++ b/UnitTests/Misc/TypeConversionTests.swift
@@ -29,6 +29,18 @@ final class TypeConversionTests: TemporaryDirectoryHelper {
         XCTAssertEqual(y, 1.25)
     }
     
+    func test_Double_from_GfHalf() {
+        let x: pxr.GfHalf = pxr.GfHalf(1.25)
+        let y: Double = Double(x)
+        XCTAssertEqual(y, 1.25)
+    }
+    
+    func test_GfHalf_from_Double() {
+        let x: Double = 1.25
+        let y: pxr.GfHalf = pxr.GfHalf(x)
+        XCTAssertEqual(y, 1.25)
+    }
+    
     func test_String_from_TfToken() {
         XCTAssertEqual(String(pxr.TfToken.UsdGeomTokens.Cube), "Cube")
     }

--- a/UnitTests/Resources/Wrapping/ArAssetWrapper/foo.txt
+++ b/UnitTests/Resources/Wrapping/ArAssetWrapper/foo.txt
@@ -1,0 +1,1 @@
+Hello, ArAssetWrapper!

--- a/UnitTests/Wrapping/TfNoticeTests.swift
+++ b/UnitTests/Wrapping/TfNoticeTests.swift
@@ -81,7 +81,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
             gotNotice += 1
         }
         XCTAssertEqual(gotNotice, 0)
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         XCTAssertEqual(gotNotice, 0)
         stage.SetStartTimeCode(5)
         XCTAssertEqual(gotNotice, 2) // Incremented by two because UsdNotice.StageNotice is a base class with a subclass that fires
@@ -98,8 +98,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
     
     func test_RegisterB() {
         let gotNotice = SendableCounter(0)
-        let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         pxr.TfNotice.Register(stage1) { (notice: pxr.UsdNotice.ObjectsChanged) in
             gotNotice += 1
@@ -125,8 +125,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
     
     func test_RegisterC() {
         let gotNotice = SendableCounter(0)
-        nonisolated(unsafe) let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        nonisolated(unsafe) let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         pxr.TfNotice.Register(stage1) { (notice: pxr.UsdNotice.ObjectsChanged, sender: pxr.UsdStage) in
             gotNotice += 1
@@ -168,7 +168,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
             }
         }
         
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         XCTAssertEqual(gotStageContentsChangedNotice, 0)
         XCTAssertEqual(gotObjectsChangedNotice, 0)
         stage.SetStartTimeCode(1)
@@ -194,8 +194,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
     func test_RegisterE() {
         let gotStageContentsChangedNotice = SendableCounter(0)
         let gotObjectsChangedNotice = SendableCounter(0)
-        let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         pxr.TfNotice.Register(stage1) { (notice: pxr.UsdNotice.StageNotice, caster) in
             if let stageContentsChanged = caster(pxr.UsdNotice.StageContentsChanged.self) {
@@ -236,8 +236,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
     func test_RegisterF() {
         let gotStageContentsChangedNotice = SendableCounter(0)
         let gotObjectsChangedNotice = SendableCounter(0)
-        nonisolated(unsafe) let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        nonisolated(unsafe) let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         pxr.TfNotice.Register(stage1) { (notice: pxr.UsdNotice.StageNotice, sender, caster) in
             if let stageContentsChanged = caster(pxr.UsdNotice.StageContentsChanged.self) {
@@ -345,7 +345,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
             gotNotice += 1
         }
         XCTAssertEqual(gotNotice, 0)
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         XCTAssertEqual(gotNotice, 0)
         stage.SetStartTimeCode(5)
         XCTAssertEqual(gotNotice, 1)
@@ -359,8 +359,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
         let aCtr = SendableCounter(0)
         let bCtr = SendableCounter(0)
         
-        let aStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let bStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let aStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let bStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         var keys = pxr.TfNotice.SwiftKeys()
         
@@ -411,7 +411,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
             gotNotice += 1
         }
         XCTAssertEqual(gotNotice, 0)
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         XCTAssertEqual(gotNotice, 0)
         stage.SetStartTimeCode(5)
         XCTAssertEqual(gotNotice, 1)
@@ -425,8 +425,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
         let aCtr = SendableCounter(0)
         let bCtr = SendableCounter(0)
         
-        let aStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-        let bStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let aStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        let bStage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         var keys = pxr.TfNotice.SwiftKeys()
         
@@ -472,7 +472,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
     }
     
     func test_callbacksAreNonConcurrent() {
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         
         let isCallbackRunning = SendableFlag(false)
         let counter = SendableCounter(0)
@@ -638,7 +638,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
         XCTAssertTrue(_xLanguage_TfNotice.test_revokeManyCppKeyViaSwiftUsd())
         
         do {
-            let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+            let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
             let callbackCount = SendableCounter(0)
             let key = pxr.TfNotice.Register(stage, pxr.UsdNotice.StageContentsChanged.self) { _ in
                 callbackCount += 1
@@ -649,8 +649,8 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
         }
         
         do {
-            let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
-            let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+            let stage1 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+            let stage2 = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
             let callbackCount1 = SendableCounter(0)
             let callbackCount2 = SendableCounter(0)
             let key1 = pxr.TfNotice.Register(stage1, pxr.UsdNotice.StageContentsChanged.self) { _ in
@@ -673,7 +673,7 @@ final class TfNoticeTests: TemporaryDirectoryHelper {
             let cppKey = p.first
             let callbackCount = p.second!
             
-            let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+            let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
             XCTAssertTrue(callbackCount() == 0)
             
             stage.SetStartTimeCode(5)

--- a/UnitTests/Wrapping/WrappedTypeTests.swift
+++ b/UnitTests/Wrapping/WrappedTypeTests.swift
@@ -770,6 +770,67 @@ final class WrappedTypeTests: HydraHelper {
         XCTAssertFalse(resolvedPath.IsEmpty())
     }
     
+    // MARK: ArAssetWrapper
+    
+    func test_ArAssetWrapper_nonexistentFile() {
+        let assetUrl = self.urlForResource(subPath: "Wrapping/ArAssetWrapper/thisfiledoesnotexist.txt")
+        let resolvedPath = pxr.ArResolvedPath(std.string(assetUrl.path(percentEncoded: false)))
+        let assetWrapper: Overlay.ArAssetWrapper = Overlay.ArGetResolver().OpenAsset(resolvedPath)
+        
+        XCTAssertFalse(Bool(assetWrapper))
+    }
+    
+    func test_ArAssetWrapper() {
+        let assetUrl = self.urlForResource(subPath: "Wrapping/ArAssetWrapper/foo.txt")
+        let resolvedPath = pxr.ArResolvedPath(std.string(assetUrl.path(percentEncoded: false)))
+        let assetWrapper: Overlay.ArAssetWrapper = Overlay.ArGetResolver().OpenAsset(resolvedPath)
+        
+        XCTAssertTrue(Bool(assetWrapper))
+        
+        let expectedContents = "Hello, ArAssetWrapper!\n"
+        XCTAssertEqual(assetWrapper.GetSize(), 23)
+        XCTAssertEqual(assetWrapper.GetSize(), expectedContents.count)
+        
+        withExtendedLifetime(assetWrapper) {
+            withExtendedLifetime(assetWrapper.GetBuffer()) { bufSharedPtr in
+                let bufPtr = bufSharedPtr.__getUnsafe()!
+                for i in 0..<min(expectedContents.count, assetWrapper.GetSize()) {
+                    expectedContents.withCString { expectedPtr in
+                        XCTAssertEqual(bufPtr[i], expectedPtr[i])
+                    }
+                }
+            }
+        }
+        
+        var data = Data(count: assetWrapper.GetSize() - 2)
+        let readRetValue = data.withUnsafeMutableBytes {
+            assetWrapper.Read($0.baseAddress, assetWrapper.GetSize() - 2, 2)
+        }
+        XCTAssertEqual(readRetValue, 21)
+        let readString = String(data: data, encoding: .utf8)
+        XCTAssertEqual(readString, "llo, ArAssetWrapper!\n")
+    }
+    
+    // MARK: ArWritableAssetWrapper
+    func test_ArWritableAssetWrapper() {
+        let url = FileManager.default.temporaryDirectory.appending(path: "ArWritableAssetWrapper.txt")
+        let resolvedPath = pxr.ArResolvedPath(std.string(url.path(percentEncoded: false)))
+        var writableAssetWrapper: Overlay.ArWritableAssetWrapper = Overlay.ArGetResolver().OpenAssetForWrite(resolvedPath, .Replace)
+        
+        XCTAssertTrue(Bool(writableAssetWrapper))
+        let s = "Hello, ArWritableAssetWrapper!\n"
+        let writeRetValue = s.withCString {
+            writableAssetWrapper.Write($0, s.count, 0)
+        }
+        XCTAssertEqual(writeRetValue, s.count)
+        
+        XCTAssertTrue(writableAssetWrapper.Close())
+        
+        let contentsWritten = try? String(contentsOf: url, encoding: .utf8)
+        XCTAssertEqual(s, contentsWritten)
+    }
+    // bool Close(), size_t Write(const void* buffer, size_t count, size_t offset)
+    
     // MARK: SdfZipFileIteratorWrapper
     
     func test_SdfZipFileIteratorWrapper() {
@@ -834,7 +895,7 @@ final class WrappedTypeTests: HydraHelper {
     // MARK: ExecUsdSystemWrapper
 
     func test_ExecUsdSystemWrapper() {
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
         stage.DefinePrim("/hello", .UsdGeomTokens.Xform)
 
         let prim = stage.DefinePrim("/hello/world", .UsdGeomTokens.Sphere)
@@ -852,7 +913,9 @@ final class WrappedTypeTests: HydraHelper {
         #if compiler(>=6.2)
         // Swift-Cxx interop only gained rvalue reference support in Swift 6.2;
         // BuildRequest(consuming:) relies on it.
-        let request = system.BuildRequest(consuming: [key])
+        var vec = Overlay.ExecUsdValueKey_Vector()
+        vec.push_back(key)
+        let request = system.BuildRequest(consuming: vec)
         Overlay.Compute(&system, request) { view in
             var val = view.Get(0)
             XCTAssertTrue(val.IsHolding(T: pxr.GfMatrix4d.self))
@@ -864,7 +927,7 @@ final class WrappedTypeTests: HydraHelper {
     }
 
     func test_ExecUsdSystemWrapper_ChildRotate_ParentTranslate() {
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
 
         // computeLocalToWorldTransform (registered in pxr/exec/execGeom) does
         // not compose a prim's own xformOpOrder - it reads a single attribute
@@ -900,7 +963,9 @@ final class WrappedTypeTests: HydraHelper {
         #if compiler(>=6.2)
         // Swift-Cxx interop only gained rvalue reference support in Swift 6.2;
         // BuildRequest(consuming:) relies on it.
-        let request = system.BuildRequest(consuming: [key])
+        var vec = Overlay.ExecUsdValueKey_Vector()
+        vec.push_back(key)
+        let request = system.BuildRequest(consuming: vec)
         Overlay.Compute(&system, request) { view in
             var val = view.Get(0)
             XCTAssertTrue(val.IsHolding(T: pxr.GfMatrix4d.self))
@@ -912,7 +977,7 @@ final class WrappedTypeTests: HydraHelper {
     }
 
     func test_ExecUsdSystemWrapper_ChildTranslate_ParentRotate() {
-        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory())
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
 
         let parentPrim = stage.DefinePrim("/hello", .UsdGeomTokens.Xform)
         let parentXformable = pxr.UsdGeomXformable(parentPrim)
@@ -943,7 +1008,9 @@ final class WrappedTypeTests: HydraHelper {
         #if compiler(>=6.2)
         // Swift-Cxx interop only gained rvalue reference support in Swift 6.2;
         // BuildRequest(consuming:) relies on it.
-        let request = system.BuildRequest(consuming: [key])
+        var vec = Overlay.ExecUsdValueKey_Vector()
+        vec.push_back(key)
+        let request = system.BuildRequest(consuming: vec)
         Overlay.Compute(&system, request) { view in
             var val = view.Get(0)
             XCTAssertTrue(val.IsHolding(T: pxr.GfMatrix4d.self))


### PR DESCRIPTION
Also add tests for `GfHalf <-> Double` conversion, and fixed an autoclosure-forwarding compiler in LibWorkTests.swift that seemed intermittent.

Changed ExecUsdSystemWrapper tests to explicitly construct a `std.vector<pxr.ExecUsdValueKey>` instead of using array literal, because the compiler wouldn't use the synthesized ExpressibleByArrayLiteral conformance for `std.vector`. (This is probably a known intermittent compiler bug where protocol conformances can be lost when crossing a module boundary, like from OpenUSD to SwiftUsd-Tests.)

Also, replaced `pxr.UsdStage.CreateInMemory()` with `pxr.UsdStage.CreateInMemory(.LoadAll)` to work around rdar://138513915 (Duplicate symbol linker error when calling C++ function without passing default arguments from multiple Swift files), fixed in Xcode 26.2 but present in Swift 6.1.