### PR TITLE
[VtArray] Add tests for withUnsafeBufferPointer and buffer init

### DIFF
--- a/UnitTests/Protocol conformances/ExpressibleByArrayLiteralTests.swift
+++ b/UnitTests/Protocol conformances/ExpressibleByArrayLiteralTests.swift
@@ -381,4 +381,51 @@ final class ExpressibleByArrayLiteralTests: TemporaryDirectoryHelper {
         XCTAssertEqual(x.description, "[(1, 2, 3, 4)]")
         assertConforms(Overlay.GfVec4f_Vector.self)
     }
+
+    // MARK: VtArray init from a contiguous buffer (single-copy construction)
+
+    func test_VtArray_initFromBuffer_int() {
+        let source: [Int32] = [5, 6, 7, 8]
+        let x = source.withUnsafeBufferPointer { pxr.VtIntArray($0) }
+        XCTAssertEqual(x.description, "[5, 6, 7, 8]")
+        XCTAssertEqual(Array(x), source)
+    }
+
+    func test_VtArray_initFromBuffer_empty() {
+        let source: [Int32] = []
+        let x = source.withUnsafeBufferPointer { pxr.VtIntArray($0) }
+        XCTAssertEqual(x.size(), 0)
+        XCTAssertEqual(x.description, "[]")
+    }
+
+    // A layout-compatible struct bound straight into GfVec3f, with no per-element conversion.
+    func test_VtArray_initFromBuffer_layoutCompatible() {
+        struct MyFloat3 { var x: Float; var y: Float; var z: Float }
+        let view = [MyFloat3(x: 1, y: 2, z: 3), MyFloat3(x: 4, y: 5, z: 6)]
+        let x: pxr.VtVec3fArray = view.withUnsafeBufferPointer { buffer in
+            let vecs = UnsafeRawPointer(buffer.baseAddress!).assumingMemoryBound(to: pxr.GfVec3f.self)
+            return pxr.VtVec3fArray(UnsafeBufferPointer(start: vecs, count: buffer.count))
+        }
+        XCTAssertEqual(x, [pxr.GfVec3f(1, 2, 3), pxr.GfVec3f(4, 5, 6)])
+    }
+
+    // A buffer-constructed array survives a Set/Get through USDAttribute.
+    func test_VtArray_initFromBuffer_roundTripsThroughUsd() {
+        let source: [Float] = [1, 0, 1, 0, 1, 0]
+        let colors: pxr.VtVec3fArray = source.withUnsafeBufferPointer { buffer in
+            let vecs = UnsafeRawPointer(buffer.baseAddress!).assumingMemoryBound(to: pxr.GfVec3f.self)
+            return pxr.VtVec3fArray(UnsafeBufferPointer(start: vecs, count: buffer.count / 3))
+        }
+        XCTAssertEqual(colors.size(), 2)
+
+        let stage = Overlay.Dereference(pxr.UsdStage.CreateInMemory(.LoadAll))
+        stage.DefinePrim("/hello/world", "Sphere")
+        let sphere = pxr.UsdGeomSphere.Get(Overlay.TfWeakPtr(stage), "/hello/world")
+        let attr = sphere.GetDisplayColorAttr()
+        XCTAssertTrue(attr.Set(colors, pxr.UsdTimeCode.Default()))
+
+        var readBack = pxr.VtVec3fArray()
+        XCTAssertTrue(attr.Get(&readBack, pxr.UsdTimeCode.Default()))
+        XCTAssertEqual(readBack, colors)
+    }
 }

--- a/UnitTests/Protocol conformances/SequenceTests.swift
+++ b/UnitTests/Protocol conformances/SequenceTests.swift
@@ -484,7 +484,65 @@ final class SequenceTests: TemporaryDirectoryHelper {
         XCTAssertEqual(Array(x), x.map { $0 })
         assertConforms(Overlay.SdfAssetPath_VtArray.self)
     }
-    
+
+    // MARK: VtArray.withUnsafeBufferPointer (zero-copy reads)
+
+    private func _assertBuffer<T: __Overlay.VtArray_WithoutCodableProtocol>(_ x: T, _ expected: [T.Element]) where T.Element == T.ElementType {
+        XCTAssertEqual(x.size(), expected.count)
+        XCTAssertEqual(x.withUnsafeBufferPointer { Array($0) }, expected)
+    }
+
+    func test_VtArray_withUnsafeBufferPointer_int() {
+        let x: pxr.VtIntArray = [3, 1, 4, 1, 5]
+        _assertBuffer(x, [3, 1, 4, 1, 5])
+    }
+
+    func test_VtArray_withUnsafeBufferPointer_float() {
+        let x: pxr.VtFloatArray = [2.5, -1, 0]
+        _assertBuffer(x, [2.5, -1, 0])
+    }
+
+    func test_VtArray_withUnsafeBufferPointer_vec3f() {
+        let x: pxr.VtVec3fArray = [pxr.GfVec3f(1, 2, 3), pxr.GfVec3f(4, 5, 6)]
+        _assertBuffer(x, [pxr.GfVec3f(1, 2, 3), pxr.GfVec3f(4, 5, 6)])
+    }
+
+    func test_VtArray_withUnsafeBufferPointer_string() {
+        let x: pxr.VtStringArray = ["foo", "bar", "baz"]
+        _assertBuffer(x, ["foo", "bar", "baz"])
+    }
+
+    // A fresh, never-filled array hands back an empty buffer rather than a
+    // dangling base pointer.
+    func test_VtArray_withUnsafeBufferPointer_empty() {
+        let x = pxr.VtIntArray()
+        var observedCount = -1
+        x.withUnsafeBufferPointer { observedCount = $0.count }
+        XCTAssertEqual(observedCount, 0)
+        _assertBuffer(x, [])
+    }
+
+    // Filled and then fully emptied reports zero, not a stale count.
+    func test_VtArray_withUnsafeBufferPointer_addedThenCleared() {
+        var x = pxr.VtIntArray()
+        x.push_back(1)
+        x.push_back(2)
+        x.push_back(3)
+        x.clear()
+        var observedCount = -1
+        x.withUnsafeBufferPointer { observedCount = $0.count }
+        XCTAssertEqual(observedCount, 0)
+        _assertBuffer(x, [])
+    }
+
+    func test_VtArray_withUnsafeBufferPointer_varyingSizes() {
+        for n in [1, 2, 7, 128, 1000] {
+            var x = pxr.VtIntArray()
+            for i in 0 ..< n { x.push_back(Int32(i)) }
+            _assertBuffer(x, (0 ..< n).map { Int32($0) })
+        }
+    }
+
     // MARK: std::vector specializations
         
     func test_StringVector() throws {


### PR DESCRIPTION
Cover zero-copy reads in SequenceTests (per-type, empty, filled then cleared, varying sizes) and single-copy construction in ExpressibleByArrayLiteralTests (scalar, empty, a layout compatible struct bound straight into `GfVec3f`, and a Set/Get through `USDAttribute`).